### PR TITLE
Added showing the prefix, setting the prefix and using it on a guild

### DIFF
--- a/cogs/guild.py
+++ b/cogs/guild.py
@@ -1,5 +1,6 @@
 from utils.checks import FileCheck
 from discord.ext import commands
+from discord.ext.commands.cooldowns import BucketType
 import discord
 from utils.embed import Embed
 import random
@@ -191,6 +192,22 @@ class Server(commands.Cog):
         with open(self.wmessage_path, 'w') as fp:
             json.dump(self.welcome_messages, fp, indent=4)
         await ctx.send("I will now send the welcome message to new members, {}!".format(ctx.author.name))
+
+    @commands.guild_only()
+    @commands.has_permissions(administrator=True)
+    @commands.command()
+    @commands.cooldown(1, 10, BucketType.guild)
+    async def prefix(self, ctx, prefix=None):
+        """Utility|Shows the prefix of the server or sets a new one|Administrator permission"""
+        if not prefix:
+            prefix = await self.bot.funx.get_prefix(ctx.guild.id)
+            if not prefix:
+                prefix = "/ ".join(self.bot.prefixes)
+            return await ctx.send("The prefix of this server is `{}`".format(prefix))
+        if len(prefix) > 3:
+            return await ctx.send("The prefix cannot be longer than 3 characters!")
+        await self.bot.funx.set_prefix(ctx.guild.id, prefix)
+        await ctx.send("The prefix on this server is now `{}`".format(prefix))
 
 
 def setup(bot):

--- a/launch.py
+++ b/launch.py
@@ -1,4 +1,6 @@
 import asyncio
+import itertools
+
 from mainbot import bot
 from utils.checks import FileCheck
 import json
@@ -25,6 +27,11 @@ async def start_bot():
     bot.owner_ids = set(setts["owner_ids"])
     bot.consts = setts["constants"]
     bot.prefixes = setts["prefixes"]
+    bot.fullpref = list()
+
+    for k in bot.prefixes:
+        bot.fullpref.extend(map(''.join, itertools.product(*zip(k.upper(), k.lower()))))
+
     db = await asyncpg.create_pool(host=db_ip, user=db_user, password=db_pass, database=db_name)
     bot.pool = db
     bot.funx = Funx(bot)

--- a/mainbot.py
+++ b/mainbot.py
@@ -7,10 +7,12 @@ import json
 import sys, traceback
 
 
-def get_prefix(bot, message):
-    fullpref = list()
-    for k in bot.prefixes:
-        fullpref.extend(map(''.join, itertools.product(*zip(k.upper(), k.lower()))))
+async def get_prefix(bot, message):
+    fullpref = bot.fullpref
+    if message.guild:
+        prefix = await bot.funx.get_prefix(message.guild.id)
+        if prefix:
+            fullpref.extend(map(''.join, itertools.product(*zip(prefix.upper(), prefix.lower()))))
     return commands.when_mentioned_or(*fullpref)(bot, message)
 
 

--- a/utils/base/amathy.sql
+++ b/utils/base/amathy.sql
@@ -50,6 +50,17 @@ create table if not exists amathy.disabled_events
 create unique index if not exists table_name_guild_id_uindex
     on amathy.disabled_events (guild_id);
 
+create table if not exists amathy.guilds
+(
+    guild_id numeric(18) not null
+        constraint guilds_pk
+            primary key,
+    prefix   text
+);
+
+create unique index if not exists guilds_guild_id_uindex
+    on amathy.guilds (guild_id);
+
 create table if not exists amathy.hentai
 (
     id   serial not null

--- a/utils/funx.py
+++ b/utils/funx.py
@@ -193,6 +193,16 @@ class Funx:
             return 0
         return inventory[item_name]
 
+    async def get_prefix(self, guild_id):
+        script = f"select prefix from amathy.guilds where guild_id={guild_id}"
+        data = await self.bot.funx.fetch_one(script)
+        if not data:
+            return None
+        prefix = data["prefix"]
+        if not prefix:
+            return None
+        return prefix
+
     @staticmethod
     def inventory_add(inventory, item_name, quantity=1):
         if item_name not in inventory:
@@ -248,6 +258,11 @@ class Funx:
     async def save_timer(self, uid, cat, val):
         val = val.strftime(self.date_format)
         script = f"insert into amathy.timers (user_id, {cat}) values ({uid}, '{val}') on conflict (user_id) do update set {cat}='{val}'"
+        await self.execute(script)
+
+    async def set_prefix(self, guild_id, val):
+        script = f"insert into amathy.guilds (guild_id, prefix) values ({guild_id}, '{val}') " \
+                 f"on conflict (guild_id) do update set prefix='{val}'"
         await self.execute(script)
 
     async def embed_menu(self, ctx, emb_list: list, message=None, page=0, timeout=30):


### PR DESCRIPTION
Added the option to show the current guild's prefix. If this is not present in the database or it is null in the `guilds` table then the default prefixes will be shown.
Added the `guilds` in the `amathy.sql` file.
Added the option to set a prefix with a length of maximum 3 characters.
The new prefix can be used in the guild along the default prefixes.