### PR TITLE
Added an efficient way to check the prefixes with case-insensitive

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -27,10 +27,6 @@ async def start_bot():
     bot.owner_ids = set(setts["owner_ids"])
     bot.consts = setts["constants"]
     bot.prefixes = setts["prefixes"]
-    bot.fullpref = list()
-
-    for k in bot.prefixes:
-        bot.fullpref.extend(map(''.join, itertools.product(*zip(k.upper(), k.lower()))))
 
     db = await asyncpg.create_pool(host=db_ip, user=db_user, password=db_pass, database=db_name)
     bot.pool = db

--- a/mainbot.py
+++ b/mainbot.py
@@ -1,19 +1,23 @@
 import discord
 from discord.ext import commands
+
 from utils.converters import MemberNotFound
-import itertools
 import os
 import json
-import sys, traceback
+import sys
+import traceback
+import re
 
 
 async def get_prefix(bot, message):
-    fullpref = bot.fullpref
+    for p in bot.prefixes:
+        if bool(re.match(p, message.content, re.I)):
+            return message.content[:len(p)]
     if message.guild:
-        prefix = await bot.funx.get_prefix(message.guild.id)
-        if prefix:
-            fullpref.extend(map(''.join, itertools.product(*zip(prefix.upper(), prefix.lower()))))
-    return commands.when_mentioned_or(*fullpref)(bot, message)
+        custom_prefix = await bot.funx.get_prefix(message.guild.id)
+        if custom_prefix and re.match(custom_prefix, message.content, re.I):
+            return message.content[:len(custom_prefix)]
+    return commands.when_mentioned(bot, message)
 
 
 def attach_cogs(bot):


### PR DESCRIPTION
I removed the `fullprefs` field.
Now it checks the message's prefix with the bot's prefixes using regular expressions (it says that this is more efficient than `lower()`) and returns the prefix from the message to be validated by the library. It also works for the guild's custom prefix.